### PR TITLE
support GODEBUG=tracebackancestors

### DIFF
--- a/test-fixtures/ancestors.go
+++ b/test-fixtures/ancestors.go
@@ -1,0 +1,73 @@
+//+build ignore
+
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+package main
+
+import (
+	"fmt"
+	"runtime"
+)
+
+// adapted from https://github.com/golang/go/issues/22289
+// run with GODEBUG=tracebackancestors=10 go run ancestors.go
+func main() {
+	w := make(chan struct{})
+	go foo(w, 5)
+	<-w
+	x := make(chan struct{})
+	go foo(x, 3)
+	<-x
+	fmt.Print(string(stackAll()))
+	close(w)
+}
+
+func stackAll() []byte {
+	buf := make([]byte, 1024)
+	for {
+		n := runtime.Stack(buf, true)
+		if n < len(buf) {
+			return buf[:n]
+		}
+		buf = make([]byte, 2*len(buf))
+	}
+}
+
+const maxStackDepth = 5
+
+func foo(w chan struct{}, timesToCallGo int) {
+	if timesToCallGo == 0 {
+		w <- struct{}{}
+		<-w
+		return
+	}
+	if timesToCallGo%2 == 0 {
+		d1(func() { foo(w, timesToCallGo-1) }, maxStackDepth)
+	} else {
+		d1(func() { bar(w, timesToCallGo-1) }, maxStackDepth)
+	}
+}
+
+func bar(w chan struct{}, timesToCallGo int) {
+	if timesToCallGo == 0 {
+		w <- struct{}{}
+		<-w
+		return
+	}
+	if timesToCallGo%2 == 0 {
+		d1(func() { foo(w, timesToCallGo-1) }, maxStackDepth)
+	} else {
+		d1(func() { bar(w, timesToCallGo-1) }, maxStackDepth)
+	}
+}
+
+func d1(fn func(), timesToRecurse int) {
+	if timesToRecurse == 0 {
+		go fn()
+		return
+	}
+	d1(fn, timesToRecurse-1)
+}

--- a/test-fixtures/ancestors.golden.json
+++ b/test-fixtures/ancestors.golden.json
@@ -1,0 +1,525 @@
+{
+  "Errors": null,
+  "Goroutines": [
+    {
+      "ID": 1,
+      "State": "running",
+      "Wait": 0,
+      "LockedToThread": false,
+      "Stack": [
+        {
+          "Func": "main.stackAll",
+          "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+          "Line": 31
+        },
+        {
+          "Func": "main.main",
+          "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+          "Line": 24
+        }
+      ],
+      "FramesElided": false,
+      "CreatedBy": null
+    },
+    {
+      "ID": 25,
+      "State": "chan receive",
+      "Wait": 0,
+      "LockedToThread": false,
+      "Stack": [
+        {
+          "Func": "main.bar",
+          "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+          "Line": 57
+        },
+        {
+          "Func": "main.foo.func2",
+          "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+          "Line": 50
+        }
+      ],
+      "FramesElided": false,
+      "CreatedBy": {
+        "Func": "main.d1",
+        "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+        "Line": 69
+      },
+      "Ancestor": {
+        "ID": 24,
+        "State": "",
+        "Wait": 0,
+        "LockedToThread": false,
+        "Stack": [
+          {
+            "Func": "main.d1",
+            "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+            "Line": 70
+          },
+          {
+            "Func": "main.d1",
+            "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+            "Line": 73
+          },
+          {
+            "Func": "main.d1",
+            "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+            "Line": 73
+          },
+          {
+            "Func": "main.d1",
+            "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+            "Line": 73
+          },
+          {
+            "Func": "main.d1",
+            "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+            "Line": 73
+          },
+          {
+            "Func": "main.d1",
+            "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+            "Line": 73
+          },
+          {
+            "Func": "main.foo",
+            "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+            "Line": 52
+          },
+          {
+            "Func": "main.bar.func1",
+            "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+            "Line": 61
+          }
+        ],
+        "FramesElided": false,
+        "CreatedBy": {
+          "Func": "main.d1",
+          "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+          "Line": 69
+        },
+        "Ancestor": {
+          "ID": 23,
+          "State": "",
+          "Wait": 0,
+          "LockedToThread": false,
+          "Stack": [
+            {
+              "Func": "main.d1",
+              "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+              "Line": 70
+            },
+            {
+              "Func": "main.d1",
+              "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+              "Line": 73
+            },
+            {
+              "Func": "main.d1",
+              "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+              "Line": 73
+            },
+            {
+              "Func": "main.d1",
+              "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+              "Line": 73
+            },
+            {
+              "Func": "main.d1",
+              "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+              "Line": 73
+            },
+            {
+              "Func": "main.d1",
+              "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+              "Line": 73
+            },
+            {
+              "Func": "main.bar",
+              "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+              "Line": 61
+            },
+            {
+              "Func": "main.foo.func2",
+              "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+              "Line": 50
+            }
+          ],
+          "FramesElided": false,
+          "CreatedBy": {
+            "Func": "main.d1",
+            "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+            "Line": 69
+          },
+          "Ancestor": {
+            "ID": 22,
+            "State": "",
+            "Wait": 0,
+            "LockedToThread": false,
+            "Stack": [
+              {
+                "Func": "main.d1",
+                "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+                "Line": 70
+              },
+              {
+                "Func": "main.d1",
+                "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+                "Line": 73
+              },
+              {
+                "Func": "main.d1",
+                "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+                "Line": 73
+              },
+              {
+                "Func": "main.d1",
+                "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+                "Line": 73
+              },
+              {
+                "Func": "main.d1",
+                "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+                "Line": 73
+              },
+              {
+                "Func": "main.d1",
+                "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+                "Line": 73
+              },
+              {
+                "Func": "main.foo",
+                "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+                "Line": 52
+              },
+              {
+                "Func": "main.bar.func1",
+                "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+                "Line": 61
+              }
+            ],
+            "FramesElided": false,
+            "CreatedBy": {
+              "Func": "main.d1",
+              "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+              "Line": 69
+            },
+            "Ancestor": {
+              "ID": 21,
+              "State": "",
+              "Wait": 0,
+              "LockedToThread": false,
+              "Stack": [
+                {
+                  "Func": "main.d1",
+                  "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+                  "Line": 70
+                },
+                {
+                  "Func": "main.d1",
+                  "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+                  "Line": 73
+                },
+                {
+                  "Func": "main.d1",
+                  "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+                  "Line": 73
+                },
+                {
+                  "Func": "main.d1",
+                  "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+                  "Line": 73
+                },
+                {
+                  "Func": "main.d1",
+                  "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+                  "Line": 73
+                },
+                {
+                  "Func": "main.d1",
+                  "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+                  "Line": 73
+                },
+                {
+                  "Func": "main.bar",
+                  "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+                  "Line": 61
+                },
+                {
+                  "Func": "main.foo.func2",
+                  "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+                  "Line": 50
+                }
+              ],
+              "FramesElided": false,
+              "CreatedBy": {
+                "Func": "main.d1",
+                "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+                "Line": 69
+              },
+              "Ancestor": {
+                "ID": 20,
+                "State": "",
+                "Wait": 0,
+                "LockedToThread": false,
+                "Stack": [
+                  {
+                    "Func": "main.d1",
+                    "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+                    "Line": 70
+                  },
+                  {
+                    "Func": "main.d1",
+                    "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+                    "Line": 73
+                  },
+                  {
+                    "Func": "main.d1",
+                    "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+                    "Line": 73
+                  },
+                  {
+                    "Func": "main.d1",
+                    "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+                    "Line": 73
+                  },
+                  {
+                    "Func": "main.d1",
+                    "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+                    "Line": 73
+                  },
+                  {
+                    "Func": "main.d1",
+                    "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+                    "Line": 73
+                  },
+                  {
+                    "Func": "main.foo",
+                    "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+                    "Line": 52
+                  }
+                ],
+                "FramesElided": false,
+                "CreatedBy": {
+                  "Func": "main.main",
+                  "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+                  "Line": 19
+                },
+                "Ancestor": {
+                  "ID": 1,
+                  "State": "",
+                  "Wait": 0,
+                  "LockedToThread": false,
+                  "Stack": [
+                    {
+                      "Func": "main.main",
+                      "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+                      "Line": 20
+                    }
+                  ],
+                  "FramesElided": false,
+                  "CreatedBy": null
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "ID": 29,
+      "State": "chan receive",
+      "Wait": 0,
+      "LockedToThread": false,
+      "Stack": [
+        {
+          "Func": "main.bar",
+          "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+          "Line": 57
+        },
+        {
+          "Func": "main.foo.func2",
+          "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+          "Line": 50
+        }
+      ],
+      "FramesElided": false,
+      "CreatedBy": {
+        "Func": "main.d1",
+        "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+        "Line": 69
+      },
+      "Ancestor": {
+        "ID": 28,
+        "State": "",
+        "Wait": 0,
+        "LockedToThread": false,
+        "Stack": [
+          {
+            "Func": "main.d1",
+            "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+            "Line": 70
+          },
+          {
+            "Func": "main.d1",
+            "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+            "Line": 73
+          },
+          {
+            "Func": "main.d1",
+            "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+            "Line": 73
+          },
+          {
+            "Func": "main.d1",
+            "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+            "Line": 73
+          },
+          {
+            "Func": "main.d1",
+            "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+            "Line": 73
+          },
+          {
+            "Func": "main.d1",
+            "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+            "Line": 73
+          },
+          {
+            "Func": "main.foo",
+            "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+            "Line": 52
+          },
+          {
+            "Func": "main.bar.func1",
+            "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+            "Line": 61
+          }
+        ],
+        "FramesElided": false,
+        "CreatedBy": {
+          "Func": "main.d1",
+          "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+          "Line": 69
+        },
+        "Ancestor": {
+          "ID": 27,
+          "State": "",
+          "Wait": 0,
+          "LockedToThread": false,
+          "Stack": [
+            {
+              "Func": "main.d1",
+              "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+              "Line": 70
+            },
+            {
+              "Func": "main.d1",
+              "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+              "Line": 73
+            },
+            {
+              "Func": "main.d1",
+              "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+              "Line": 73
+            },
+            {
+              "Func": "main.d1",
+              "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+              "Line": 73
+            },
+            {
+              "Func": "main.d1",
+              "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+              "Line": 73
+            },
+            {
+              "Func": "main.d1",
+              "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+              "Line": 73
+            },
+            {
+              "Func": "main.bar",
+              "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+              "Line": 61
+            },
+            {
+              "Func": "main.foo.func2",
+              "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+              "Line": 50
+            }
+          ],
+          "FramesElided": false,
+          "CreatedBy": {
+            "Func": "main.d1",
+            "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+            "Line": 69
+          },
+          "Ancestor": {
+            "ID": 26,
+            "State": "",
+            "Wait": 0,
+            "LockedToThread": false,
+            "Stack": [
+              {
+                "Func": "main.d1",
+                "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+                "Line": 70
+              },
+              {
+                "Func": "main.d1",
+                "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+                "Line": 73
+              },
+              {
+                "Func": "main.d1",
+                "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+                "Line": 73
+              },
+              {
+                "Func": "main.d1",
+                "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+                "Line": 73
+              },
+              {
+                "Func": "main.d1",
+                "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+                "Line": 73
+              },
+              {
+                "Func": "main.d1",
+                "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+                "Line": 73
+              },
+              {
+                "Func": "main.foo",
+                "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+                "Line": 52
+              }
+            ],
+            "FramesElided": false,
+            "CreatedBy": {
+              "Func": "main.main",
+              "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+              "Line": 22
+            },
+            "Ancestor": {
+              "ID": 1,
+              "State": "",
+              "Wait": 0,
+              "LockedToThread": false,
+              "Stack": [
+                {
+                  "Func": "main.main",
+                  "File": "/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go",
+                  "Line": 23
+                }
+              ],
+              "FramesElided": false,
+              "CreatedBy": null
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/test-fixtures/ancestors.txt
+++ b/test-fixtures/ancestors.txt
@@ -1,0 +1,175 @@
+goroutine 1 [running]:
+main.stackAll()
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:31 +0x8c
+main.main()
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:24 +0xb8
+
+goroutine 25 [chan receive]:
+main.bar(0x140000a4060, 0x0)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:57 +0x11c
+main.foo.func2()
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:50 +0x34
+created by main.d1
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:69 +0x34
+[originating from goroutine 24]:
+main.d1(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:70 +0x34
+main.d1(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:73 +0x54
+main.d1(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:73 +0x54
+main.d1(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:73 +0x54
+main.d1(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:73 +0x54
+main.d1(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:73 +0x54
+main.foo(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:52 +0xec
+main.bar.func1(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:61 +0x34
+created by main.d1
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:69 +0x34
+[originating from goroutine 23]:
+main.d1(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:70 +0x34
+main.d1(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:73 +0x54
+main.d1(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:73 +0x54
+main.d1(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:73 +0x54
+main.d1(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:73 +0x54
+main.d1(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:73 +0x54
+main.bar(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:61 +0x88
+main.foo.func2(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:50 +0x34
+created by main.d1
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:69 +0x34
+[originating from goroutine 22]:
+main.d1(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:70 +0x34
+main.d1(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:73 +0x54
+main.d1(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:73 +0x54
+main.d1(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:73 +0x54
+main.d1(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:73 +0x54
+main.d1(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:73 +0x54
+main.foo(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:52 +0xec
+main.bar.func1(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:61 +0x34
+created by main.d1
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:69 +0x34
+[originating from goroutine 21]:
+main.d1(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:70 +0x34
+main.d1(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:73 +0x54
+main.d1(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:73 +0x54
+main.d1(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:73 +0x54
+main.d1(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:73 +0x54
+main.d1(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:73 +0x54
+main.bar(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:61 +0x88
+main.foo.func2(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:50 +0x34
+created by main.d1
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:69 +0x34
+[originating from goroutine 20]:
+main.d1(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:70 +0x34
+main.d1(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:73 +0x54
+main.d1(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:73 +0x54
+main.d1(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:73 +0x54
+main.d1(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:73 +0x54
+main.d1(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:73 +0x54
+main.foo(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:52 +0xec
+created by main.main
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:19 +0x58
+[originating from goroutine 1]:
+main.main(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:20 +0x58
+
+goroutine 29 [chan receive]:
+main.bar(0x140000a4240, 0x0)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:57 +0x11c
+main.foo.func2()
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:50 +0x34
+created by main.d1
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:69 +0x34
+[originating from goroutine 28]:
+main.d1(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:70 +0x34
+main.d1(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:73 +0x54
+main.d1(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:73 +0x54
+main.d1(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:73 +0x54
+main.d1(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:73 +0x54
+main.d1(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:73 +0x54
+main.foo(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:52 +0xec
+main.bar.func1(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:61 +0x34
+created by main.d1
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:69 +0x34
+[originating from goroutine 27]:
+main.d1(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:70 +0x34
+main.d1(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:73 +0x54
+main.d1(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:73 +0x54
+main.d1(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:73 +0x54
+main.d1(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:73 +0x54
+main.d1(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:73 +0x54
+main.bar(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:61 +0x88
+main.foo.func2(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:50 +0x34
+created by main.d1
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:69 +0x34
+[originating from goroutine 26]:
+main.d1(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:70 +0x34
+main.d1(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:73 +0x54
+main.d1(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:73 +0x54
+main.d1(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:73 +0x54
+main.d1(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:73 +0x54
+main.d1(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:73 +0x54
+main.foo(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:52 +0xec
+created by main.main
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:22 +0xa4
+[originating from goroutine 1]:
+main.main(...)
+	/Users/eric/Downloads/gostackparse/test-fixtures/ancestors.go:23 +0xa4


### PR DESCRIPTION
This ends up supporting and fixing an error case where `GODEBUG=tracebackancestors=n` is being used. The purpose of this feature is outlined in the proposal here https://github.com/golang/go/issues/22289.

Supporting is not too hard as it just involves changing the current g to be an ancestor instead of the next goroutine. Keep in mind that the debug feature does not save much goroutine information so some fields will be zero values. Having this be a tree of ancestors will allow for features of detecting similar matching sub-trees of ancestries.

cc: @MichaelSnowden