### PR TITLE
fix: support windows

### DIFF
--- a/test-fixtures/windows.golden.json
+++ b/test-fixtures/windows.golden.json
@@ -1,0 +1,20 @@
+{
+  "Errors": null,
+  "Goroutines": [
+    {
+      "ID": 1,
+      "State": "running",
+      "Wait": 0,
+      "LockedToThread": false,
+      "Stack": [
+        {
+          "Func": "runtime/pprof.writeGoroutineStacks",
+          "File": "C:/Users/felixge/pprof.go",
+          "Line": 693
+        }
+      ],
+      "FramesElided": false,
+      "CreatedBy": null
+    }
+  ]
+}

--- a/test-fixtures/windows.txt
+++ b/test-fixtures/windows.txt
@@ -1,0 +1,3 @@
+goroutine 1 [running]:
+runtime/pprof.writeGoroutineStacks(0x14e5940, 0xc0000abc50, 0x101b8a5, 0xc000333d20)
+	C:/Users/felixge/pprof.go:693 +0x9f


### PR DESCRIPTION
Seemss like this also made the code a little faster :)

name             old time/op    new time/op    delta
Gostackparse-12    26.9µs ± 6%    25.3µs ± 1%   -5.97%  (p=0.000 n=10+10)

name             old MiB/s      new MiB/s      delta
Gostackparse-12       295 ± 5%       314 ± 1%   +6.27%  (p=0.000 n=10+10)

name             old alloc/op   new alloc/op   delta
Gostackparse-12    17.2kB ± 0%    17.2kB ± 0%   -0.19%  (p=0.000 n=10+10)

name             old allocs/op  new allocs/op  delta
Gostackparse-12       306 ± 0%       248 ± 0%  -18.95%  (p=0.000 n=10+10)