### PR TITLE
gostackparse: handle parent goroutine IDs in stack traces

### DIFF
--- a/gostackparse.go
+++ b/gostackparse.go
@@ -214,6 +214,17 @@ func parseGoroutineHeader(line []byte) *Goroutine {
 func parseFunc(line []byte, state parserState) *Frame {
 	// createdBy func calls don't have trailing parens, just return them as-is.
 	if state == stateCreatedByFunc {
+		// go 1.21 changes the "created by" line to include the
+		// goroutine which created the one whose stack is being printed,
+		// e.g.
+		//	created by main.main in goroutine 1
+		// We are at the beginning of the function name, so we should
+		// just show up to the first space which follows the end of the
+		// function name.
+		i := bytes.Index(line, []byte(" "))
+		if i > 0 {
+			return &Frame{Func: string(line[:i])}
+		}
 		return &Frame{Func: string(line)}
 	}
 

--- a/gostackparse_test.go
+++ b/gostackparse_test.go
@@ -49,7 +49,7 @@ func TestParse_GoldenFiles(t *testing.T) {
 			ioutil.WriteFile(golden, actual, 0644)
 		}
 		expected, _ := ioutil.ReadFile(golden)
-		require.True(t, bytes.Equal(actual, expected), golden)
+		require.JSONEq(t, string(expected), string(actual))
 	}
 }
 

--- a/test-fixtures/go121_createdby.go
+++ b/test-fixtures/go121_createdby.go
@@ -1,4 +1,5 @@
 //go:build ignore
+// +build ignore
 
 package main
 

--- a/test-fixtures/go121_createdby.go
+++ b/test-fixtures/go121_createdby.go
@@ -1,0 +1,25 @@
+//go:build ignore
+
+package main
+
+import (
+	"fmt"
+	"runtime"
+	"sync"
+)
+
+func main() {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		printStack()
+	}()
+	wg.Wait()
+}
+
+func printStack() {
+	buf := make([]byte, 1<<20)
+	n := runtime.Stack(buf, true)
+	fmt.Printf("%s\n", buf[:n])
+}

--- a/test-fixtures/go121_createdby.golden.json
+++ b/test-fixtures/go121_createdby.golden.json
@@ -1,0 +1,54 @@
+{
+  "Errors": null,
+  "Goroutines": [
+    {
+      "ID": 18,
+      "State": "running",
+      "Wait": 0,
+      "LockedToThread": false,
+      "Stack": [
+        {
+          "Func": "main.printStack",
+          "File": "/Users/nick.ripley/repos/gostackparse/test-fixtures/go121_createdby.go",
+          "Line": 23
+        },
+        {
+          "Func": "main.main.func1",
+          "File": "/Users/nick.ripley/repos/gostackparse/test-fixtures/go121_createdby.go",
+          "Line": 16
+        }
+      ],
+      "FramesElided": false,
+      "CreatedBy": {
+        "Func": "main.main",
+        "File": "/Users/nick.ripley/repos/gostackparse/test-fixtures/go121_createdby.go",
+        "Line": 14
+      }
+    },
+    {
+      "ID": 1,
+      "State": "semacquire",
+      "Wait": 0,
+      "LockedToThread": false,
+      "Stack": [
+        {
+          "Func": "sync.runtime_Semacquire",
+          "File": "/Users/nick.ripley/repos/go/src/runtime/sema.go",
+          "Line": 62
+        },
+        {
+          "Func": "sync.(*WaitGroup).Wait",
+          "File": "/Users/nick.ripley/repos/go/src/sync/waitgroup.go",
+          "Line": 116
+        },
+        {
+          "Func": "main.main",
+          "File": "/Users/nick.ripley/repos/gostackparse/test-fixtures/go121_createdby.go",
+          "Line": 18
+        }
+      ],
+      "FramesElided": false,
+      "CreatedBy": null
+    }
+  ]
+}

--- a/test-fixtures/go121_createdby.txt
+++ b/test-fixtures/go121_createdby.txt
@@ -1,0 +1,15 @@
+goroutine 18 [running]:
+main.printStack()
+	/Users/nick.ripley/repos/gostackparse/test-fixtures/go121_createdby.go:23 +0x40
+main.main.func1()
+	/Users/nick.ripley/repos/gostackparse/test-fixtures/go121_createdby.go:16 +0x4c
+created by main.main in goroutine 1
+	/Users/nick.ripley/repos/gostackparse/test-fixtures/go121_createdby.go:14 +0x70
+
+goroutine 1 [semacquire]:
+sync.runtime_Semacquire(0x140000021a0?)
+	/Users/nick.ripley/repos/go/src/runtime/sema.go:62 +0x2c
+sync.(*WaitGroup).Wait(0x1400011a010)
+	/Users/nick.ripley/repos/go/src/sync/waitgroup.go:116 +0x74
+main.main()
+	/Users/nick.ripley/repos/gostackparse/test-fixtures/go121_createdby.go:18 +0x78


### PR DESCRIPTION
Go 1.21 will change stack traces to include the ID of the parent goroutine in a
goroutine's stack trace, e.g.

```
goroutine 18 [running]:
< ... stack frames ... >
created by main.main in goroutine 1
```

(see https://go.dev/cl/435337). Handle this by consuming just the function
name, up to the first space, rather than the whole line.
