### PR TITLE
[PROF-11988] Add native go fuzzing for Parse

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,23 +2,23 @@ name: Go
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.16
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.24
 
-    - name: Build
-      run: go build -v ./...
+      - name: Build
+        run: go build -v ./...
 
-    - name: Test
-      run: go test -v ./...
+      - name: Test
+        run: go test -v ./...

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,11 @@
 module github.com/DataDog/gostackparse
 
-go 1.16
+go 1.18
 
 require github.com/stretchr/testify v1.7.0
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
+)

--- a/gostackparse.go
+++ b/gostackparse.go
@@ -83,13 +83,12 @@ func Parse(r io.Reader) ([]*Goroutine, []error) {
 				goroutines = append(goroutines, g)
 			}
 			if state == stateOriginatingFrom {
-				// A truncated line that starts with "[originating from goroutine " but doesn't contain anything else afterwards
-				endOfIDStr := len(line) - 2
-				if endOfIDStr < len(originatingFromPrefix) {
-					abortGoroutine("invalid originating from goroutine id")
-					continue
-				}
-				ancestorIDStr := line[len(originatingFromPrefix):endOfIDStr]
+				// Make sure we capture only the ID that we need. If it's truncated,
+				// it'll be handled by the error check below
+				ancestorIDStr := bytes.TrimSuffix(
+					bytes.TrimPrefix(line, originatingFromPrefix),
+					[]byte("]:"),
+				)
 				ancestorID, err := strconv.Atoi(string(ancestorIDStr))
 				if err != nil {
 					abortGoroutine(err.Error())

--- a/gostackparse.go
+++ b/gostackparse.go
@@ -83,7 +83,13 @@ func Parse(r io.Reader) ([]*Goroutine, []error) {
 				goroutines = append(goroutines, g)
 			}
 			if state == stateOriginatingFrom {
-				ancestorIDStr := line[len(originatingFromPrefix) : len(line)-2]
+				// A truncated line that starts with "[originating from goroutine " but doesn't contain anything else afterwards
+				endOfIDStr := len(line) - 2
+				if endOfIDStr < len(originatingFromPrefix) {
+					abortGoroutine("invalid originating from goroutine id")
+					continue
+				}
+				ancestorIDStr := line[len(originatingFromPrefix):endOfIDStr]
 				ancestorID, err := strconv.Atoi(string(ancestorIDStr))
 				if err != nil {
 					abortGoroutine(err.Error())


### PR DESCRIPTION
# Description

This PR adds a fuzz test for the `Parse` function.
It discovered a bug in the current implementation, which I've tentatively added as a second commit.
Running the same fuzzer for multiple minutes didn't caused any issues. (It's not a very long time for a fuzzer, I'll let it run for longer, but it's also not a very large program)

Currently this fuzz test is not run automatically, but we are working on CI integration that will be able to run these in the internal fuzzing infrastructure.

You can run the fuzz test locally by running: `go test -fuzz=FuzzParse -run=FuzzParse`


## Bug found

A crafted go stack trace containing the following bytes :`goroutine 0 [0]:\n0()\n\t:0\n[originating from goroutine "` would cause a panic.


## Root cause analysis of the bug

By using a line that starts with the `originatingFromPrefix` (`[]byte("[originating from goroutine ")`), but that does not contain any goroutine number afterward (or, for that matter, anything at all), the program was attempting the read the length of the line. Without anything after it, like the closing of the bracket `]` (string size, - 1 "bracket", -1 of "slice index start at 0 offset" so `-2`), this causes a read out of bound in the line slice. Causing a panic like so: `panic: runtime error: slice bounds out of range [28:26]`

28 being equal to the length of the string `[originating from goroutine `, if the lines only contains that, it'll be len(line) == 28, 28-2 == 26.


## Proposed bugfix

The proposed bugfix makes sure that the string contains at least the length of the prefix otherwise return an error. I chose to use `abortGoroutine` if it's not the case, as it looks like other "bad" condition are also doing.

Returning a 0 value or "continuing" the for loop/goto do not seem to be in line with the other error handling.

## Impact

This bugs come from searching around dd-trace-go, and especially this: https://github.com/DataDog/dd-trace-go/blob/f92a95e4313dda76ac10592731652e282e9fd66b/profiler/profile.go#L434-L445
Since it's guarded via a `recover` call, the impact here should be minimal.

After an internal repository search, there's another application that uses this but, as far as I understand, only in tests.
And, In The Wild :tm:, looks like there's around 86 files over github that uses this, and as far as I can tell, none are doing `recover` on it (but most of them seem to not run on user facing stacktrace)


Note: I pushed these into a single PR, to both show the additionnal fuzz and its fix so CI can be green. But happy to split and push for  a fix in another PR.
